### PR TITLE
Maintenance updates

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Mark stale issues
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 permissions:
   issues: write
   pull-requests: write
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-close: 7
+          days-before-close: 14
           days-before-stale: 60
           close-issue-message: StaleBot closed the issue due to prolonged inactivity.
           close-pr-message: StaleBot closed the pull request due to prolonged inactivity.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - CI/CD
   - [CodeRabbit](https://www.coderabbit.ai/)
   - [ImgBot](https://imgbot.net/)
+  - Linting on GitHub Actions
+  - Stale issues and pull requests management on GitHub Actions
 - Documents for GitHub
 - Git attributes
 - Linters


### PR DESCRIPTION
## Documentation

- ca540a4: Improved the README

## CI/CD

- d52637c: update cron schedule to run stale job weekly on Mondays


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow to run stale issue checks weekly instead of daily and extended the period before closing stale issues or pull requests.
* **Documentation**
  * Added information about linting and stale issue management to the CI/CD section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->