### PR TITLE
cumulative updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,3 @@
----
 name: ✨ Feature request
 description: Suggest an idea for this project
 labels: enhancement

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,10 +6,10 @@ line-length:
   code_blocks: false
   headings: false
   tables: false
-# Allows the use of duplicate headings. The default is unconditional
-# prohibition. Due to the `siblings_only` flag not working, it is necessary
-# to enable duplicate headings in the entire document.
-no-duplicate-heading: false
+# Allows the use of duplicate headings across different sections while
+# still catching true duplicates among sibling headings.
+no-duplicate-heading:
+  siblings_only: true
 # Allows embedding of the specified HTML tag. The default is unconditional
 # prohibition. Allow for some valuable features, such as folding.
 no-inline-html:


### PR DESCRIPTION
- 6754d7d13b99768dd3b9891e164d7e8fe1e9f951: use siblings_only instead of disabling duplicate heading rule
- 1e97cbc9e62fcb309ce8ee7b304785468dff9a83: remove inconsistent yaml document separator