### PR TITLE
fix(security): remove alternative reporting methods for vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,10 +19,5 @@ report it through
 [GitHub Security Advisories](https://github.com/kurone-kito/template/security/advisories/new)
 so the issue can be addressed privately before public disclosure.
 
-If you are unable to use Security Advisories, you may alternatively
-[open an issue](https://github.com/kurone-kito/template/issues) with the
-"security" label or submit a
-[pull request with a fix](https://github.com/kurone-kito/template/pulls).
-
 Your contributions to improving the security of this project are greatly
 appreciated.


### PR DESCRIPTION
SECURITY.md recommends GitHub Security Advisories, which is a good thing in itself.
However, it mentions security labels for issues and PRs as an alternative when that isn’t possible.

This wording should be toned down.
It’s risky to include details of vulnerabilities, reproduction steps, or logs showing secret leaks in public issues.