### PR TITLE
fix(gitignore): stop excluding .claude/ as a whole directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,8 +119,17 @@ $RECYCLE.BIN/
 ### THE PROJECT SPECIFIES #################################################
 
 ### AI Agents ###
-# Claude Code local config
-.claude/
+# Claude Code local config (settings.local.json, cache, etc.) stays
+# local-only, but project-shared resources under .claude/skills,
+# .claude/agents, .claude/commands, and the curated .claude/settings.json
+# permission baseline ship with the repository. Uses the same
+# wildcard-plus-negation shape as .vscode/* above -- a trailing-slash
+# whole-directory exclude would make later "!" re-includes inert.
+.claude/*
+!.claude/settings.json
+!.claude/skills/
+!.claude/agents/
+!.claude/commands/
 
 # OpenAI Codex sandbox
 .codex/


### PR DESCRIPTION
## Summary

- Switch the `### AI Agents ###` block's Claude Code lines from a
  trailing-slash whole-directory `.claude/` exclude to `.claude/*`
  plus targeted `!` re-includes for `settings.json`, `skills/`,
  `agents/`, and `commands/` -- the same shape already used for
  `.vscode/*` above.
- The whole-directory form made every later `!` rescue inert (git
  never descends into an excluded directory), so the project-shared
  half of `.claude/` (the permission/hooks/MCP `settings.json`
  baseline, plus `skills/`, `agents/`, `commands/`) could never be
  committed without `git add -f`.
- This repository seeds several other repositories, so the fix here
  stops the broken pattern from propagating further.

Closes #24.

## Test plan

- [x] `git add --dry-run` confirms scratch files under
      `.claude/settings.json`, `.claude/skills/`, `.claude/agents/`,
      and `.claude/commands/` are no longer ignored (verified, then
      removed before commit).
- [x] `.claude/settings.local.json` and an arbitrary file directly
      under `.claude/` remain ignored -- the fix doesn't widen tracking
      beyond the four named subpaths.
- [x] `.gitignore` is excluded from this repo's own cspell scan
      (`ignorePaths: .*ignore` in `.cspell.config.yml`), so the new
      comment text needs no dictionary additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to selectively track approved development settings and resources.
  * Improved consistency for shared development setup files while continuing to exclude unrelated local configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->